### PR TITLE
Fix empty database dashboard bug

### DIFF
--- a/src/backend/api/user_service.py
+++ b/src/backend/api/user_service.py
@@ -89,7 +89,7 @@ def retrieve_missing_reports(conn, owner_id) -> Tuple[str, int]:
     if len(missing_reports) > 0:
         return missing_reports, 200
     elif len(missing_reports) == 0:
-        return "Empty", 204
+        return [], 204
     else:
         return "Fail", 400
 


### PR DESCRIPTION
Previously, if the user had no missing reports in the database, the dashboard would error. This was due to a bad return type for the API call
The issue is now fixed!